### PR TITLE
fix(imports): release 0.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatfile-csv-importer",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A simple adapter for elegantly importing CSV files via flatfile.io (Typescript, ES6, Browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import 'promise-polyfill/src/polyfill'
+import 'promise-polyfill/dist/polyfill'
 
 import { EventEmitter } from 'eventemitter3'
 import whenDomReady from 'when-dom-ready'
@@ -287,7 +287,7 @@ export default class FlatfileImporter extends EventEmitter {
         fieldHookCallback: (values, meta) => {
           const fieldHook = this.$fieldHooks.find(v => v.field === meta.field)
           if (!fieldHook) {
-            return
+            return undefined
           }
           return fieldHook.cb(values, meta)
         },


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Fixes an issue that was causing a crash when using the Adapter within JavaScript environments that don't have the ability to `import` outside of a module.

* **What is the current behavior?**

SyntaxError: Cannot use import statement outside a module

* **What is the new behavior?**

Smooth sailing ⛵