### PR TITLE
changing default version in a new package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "flatfile-csv-importer",
-  "version": "0.2.13",
-  "description": "A simple adapter for elegantly importing CSV files via flatfile.io (Typescript, ES6, Browser)",
+  "name": "@flatfile/adapter",
+  "version": "2.0.0",
+  "description": "A lightweight adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/module/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import IValidationResponse, { IDataHookRecord, IDataHookResponse } from './obj.v
 export default class FlatfileImporter extends EventEmitter {
 
   public static Promise = Promise
-  private static MOUNT_URL: string = 'https://kiosk-lite.flatfile.io/?key=:key'
+  private static MOUNT_URL: string = 'https://portal-2.flatfile.io/?key=:key'
 
   /**
    * Promise that resolves when the handshake is completed between Flatfile.io and the adapter


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

changes the default mount url to portal 2

* **What is the current behavior?** (You can also link to an open issue here)

sets the url to v1

* **What is the new behavior (if this is a feature change)?**

sets the url to v2

* **Other information**:
will be published to a new npm package