### PR TITLE
chore(ie-11): add document contains polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A lightweight adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/document.contains.polyfill.ts
+++ b/src/document.contains.polyfill.ts
@@ -1,0 +1,27 @@
+const contains = function (other) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument is required')
+  }
+  if (typeof other !== 'object') {
+    throw new TypeError('Argument 1 (”other“) to Node.contains must be an instance of Node')
+  }
+
+  let node = other
+  do {
+    if (this === node) {
+      return true
+    }
+    if (node) {
+      node = node.parentNode
+    }
+  } while (node)
+
+  return false
+}
+
+export default function registerDocumentContainsPolyfill () {
+  // tslint:disable-next-line
+  if (typeof document.contains !== 'function') {
+    Object.getPrototypeOf(document).contains = contains
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,15 @@ import whenDomReady from 'when-dom-ready'
 import insertCss from 'insert-css'
 import elementClass from 'element-class'
 import Penpal from 'penpal'
+import registerDocumentContainsPolyfill from './document.contains.polyfill'
 import FlatfileResults from './results'
 import Meta from './obj.meta'
 import RecordObject from './obj.record'
 import CustomerObject from './obj.customer'
 import LoadOptionsObject from './obj.load-options'
 import IValidationResponse, { IDataHookRecord, IDataHookResponse } from './obj.validation-response'
+
+registerDocumentContainsPolyfill()
 
 export default class FlatfileImporter extends EventEmitter {
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds document.contains polyfill manually to enable IE-11 support

* **What is the current behavior?** (You can also link to an open issue here)

Situationally-breaks in IE-11

* **What is the new behavior (if this is a feature change)?**

Fixes IE-11 support
