### PR TITLE
recordHook to accept batches of rows;

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+  - 15
+  - 14
   - 8
-  - 6
-  - 4
 after_success:
   - yarn send-coverage

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export default class FlatfileImporter extends EventEmitter {
   open (options = {}): void {
     options = {
       ...options,
+      bulkInit: true,
       hasRecordHook: !!this.$recordHook,
       fieldHooks: this.$fieldHooks.map(v => v.field),
       endUser: this.customer
@@ -295,6 +296,9 @@ export default class FlatfileImporter extends EventEmitter {
         },
         dataHookCallback: (row, index, mode) => {
           return this.$recordHook ? this.$recordHook(row, index, mode) : undefined
+        },
+        bulkHookCallback: (rows, mode) => {
+          return this.$recordHook ? Promise.all(rows.map(([row, index]) => this.$recordHook!(row, index, mode))) : undefined
         },
         fieldHookCallback: (values, meta) => {
           const fieldHook = this.$fieldHooks.find(v => v.field === meta.field)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
dataHook accepts each row to be validated in recordHook


* **What is the new behavior (if this is a feature change)?**
bulkHook will accept a batch of rows to be validated in recordHook


* **Other information**:

in open options it specifies {bulkInit: true} to let Portal know that this version of adapter accepts bulkHook
