### PR TITLE
feat(adapter): displaySuccess to return promise that will be resolved…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Add the following code before the ending `</body>` tag in your html.
 
     // replace this setTimeout with an ajax request to your server with the data
     doSomethingWithYourData(results.data).then(function() {
-      importer.displaySuccess()
+      importer.displaySuccess().then(function() {
+        console.log('User closed the dialog');
+      })
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,10 +184,21 @@ export default class FlatfileImporter extends EventEmitter {
   /**
    * This will display a dialog inside of the importer with a success icon and the message you
    * pass.
+   * 
+   * @return Promise that will be resolved when user closes the dialog.
    */
-  displaySuccess(msg?: string): void {
+  displaySuccess(msg?: string): Promise<void> {
     this.$ready.then((child) => {
       child.displaySuccess(msg)
+    })
+
+    return new Promise((resolve) => {
+      const handleSuccess = () => {
+        resolve()
+        this.removeListener('close', handleSuccess)
+      }
+
+      this.on('close', handleSuccess)
     })
   }
 


### PR DESCRIPTION
… when user closes the dialog

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
`displaySuccess()` doesn't return anything


* **What is the new behavior (if this is a feature change)?**
`displaySuccess()` returns a Promise that will be resolved when user closes the dialog;


* **Other information**:
Fixes #72 
