### PR TITLE
feat(adapter): displayError to accept corrections from user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A lightweight adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,10 +173,16 @@ export default class FlatfileImporter extends EventEmitter {
    * This will display a dialog inside of the importer with an error icon and the message you
    * pass. The user will be able to acknowledge the error and be returned to the import data
    * spreadsheet to ideally fix any issues or attempt submitting again.
+   *
+   * @param corrections - allows user to do server-side validation and provide error / warning
+   * messages or value overrides
    */
-  requestCorrectionsFromUser(msg?: string): Promise<FlatfileResults> {
+  requestCorrectionsFromUser(
+    msg?: string,
+    corrections?: IDataHookResponse[]
+  ): Promise<FlatfileResults> {
     this.$ready.then((child) => {
-      child.displayError(msg)
+      child.displayError(msg, corrections)
     })
     return this.responsePromise()
   }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Customer to be able to validate results on submit (server-side) and send corrections / errors / warnings using `.requestCorrectionsFromUser(msg, corrections)`

**_the second parameter has to be the same as in `registerRecordHook()`_**

```js
importer.requestCorrectionsFromUser(
  'Server-side validation failed',
 [
    {
      id: {
        value: 'NEW VALUE',
        info: [{
          message: 'Updated value from server-side',
          level: 'error'
        }]
    }
 ]
)
```

* **What is the new behavior (if this is a feature change)?**
no ability to pass corrections


* **Other information**:
-