### PR TITLE
chore(adapter): added settings and theme interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.4.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4682,6 +4682,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
+    },
+    "csstype": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+      "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A lightweight adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -124,6 +124,7 @@
     ]
   },
   "dependencies": {
+    "csstype": "^3.0.6",
     "element-class": "^0.2.2",
     "es6-promise": "^4.2.8",
     "eventemitter3": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "A lightweight adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import LoadOptionsObject from './obj.load-options'
 import { IDataHookRecord, IDataHookResponse } from './obj.validation-response'
 import { IBeforeFetchRequest, IBeforeFetchResponse } from './obj.before-fetch'
 import { IInteractionEvent } from './obj.interaction-event'
+import { ISettings } from './obj.settings'
 
 registerDocumentContainsPolyfill()
 
@@ -27,7 +28,7 @@ export default class FlatfileImporter extends EventEmitter {
   public $ready: Promise<any>
 
   private apiKey: string
-  private options: object
+  private options: ISettings
   private customer?: CustomerObject
   private uuid: string
 
@@ -46,7 +47,7 @@ export default class FlatfileImporter extends EventEmitter {
   ) => IDataHookResponse | Promise<IDataHookResponse>
   private $fieldHooks: Array<{ field: string; cb: FieldHookCallback }> = []
 
-  constructor(apiKey: string, options: object, customer?: CustomerObject) {
+  constructor(apiKey: string, options: ISettings, customer?: CustomerObject) {
     super()
     this.apiKey = apiKey
     this.options = options

--- a/src/obj.settings.ts
+++ b/src/obj.settings.ts
@@ -1,0 +1,238 @@
+import { ITheme } from './obj.theme'
+
+export interface ISettings {
+  /**
+   * Type of record that is being imported. eg. "User", "Transaction"
+   */
+  type: string
+
+  /**
+   * Adds custom header for importer
+   */
+  title?: string
+
+  /**
+   * Configure the fields to map the uploaded data to. Easily setup validation,
+   * format hinting and more.
+   */
+  fields: IField[]
+
+  /**
+   * Specific overrides to allow theming.
+   * @deprecated use `theme`
+   */
+  styleOverrides?: IStyleOverrides
+
+  /**
+   * Overrides to allow theming for most Portal elements.
+   */
+  theme?: ITheme
+  /**
+   * Boolean configuration which turns on dashboard functionality and sends data
+   * to Flatfile's servers.
+   */
+  managed?: boolean
+
+  /**
+   * Limits file upload size to the specified number of bytes.
+   */
+  maxSize?: number
+
+  /**
+   * Limits file upload size to the specified number of rows.
+   */
+  maxRecords?: number
+
+  /**
+   * Disables the ability of the user to input directly on the first step.
+   */
+  disableManualInput?: boolean
+
+  /**
+   * Whether or not to allow importing extra fields
+   * that you have not specified in your target field map.
+   */
+  allowCustom?: boolean
+
+  /**
+   * Whether or not to allow submitting data that still has invalid cells in it.
+   */
+  allowInvalidSubmit?: boolean
+
+  /**
+   * Allows use of non-standard fonts
+   */
+  integrations?: IIntegrations
+
+  /**
+   * Allow overriding any internationalized value
+   */
+  i18nOverrides?: IDictionary<IDictionary<string>> | IDictionary<II18nOverrides>
+
+  /**
+   * URL to post batch rows to on successful import
+   */
+  webhookUrl?: string
+
+  /**
+   * Force the ability of the user to input directly on the first step.
+   */
+  forceManualInput?: boolean
+
+  /**
+   * Specify the encoding of the file upload
+   */
+  encoding?: string
+
+  /**
+   * Whether or not to allow users to select encoding
+   */
+  displayEncoding?: boolean
+
+  /**
+   * Allows for additional rows to be added to the initial rows checked on import.
+   */
+  preloadRowCount?: number
+
+  /**
+   * Boolean configuration which sets disables billing for development uploads
+   */
+  devMode?: boolean
+}
+
+export type IField = IFieldBase | IFieldSelect
+
+export interface IFieldBase {
+  key: string
+  label: string
+  description?: string
+  shortDescription?: string
+  alternates?: string[]
+  validators?: IValidator[]
+  type?: 'checkbox' | 'string'
+  sizeHint?: number
+}
+
+export type IFieldSelectMatchStrategy = 'fuzzy' | 'exact'
+
+export interface IFieldSelect extends Omit<IFieldBase, 'type'> {
+  type: 'select'
+  matchStrategy?: IFieldSelectMatchStrategy
+  options: IFieldOption[]
+}
+
+export type IValidator =
+  | IValidatorRegexDictionary
+  | IValidatorRequiredWithDictionary
+  | IValidatorOtherDictionary
+
+export interface IBaseValidatorDictionary {
+  error?: string
+}
+
+export interface IRegexFlags {
+  ignoreCase?: boolean
+  multiline?: boolean
+  dotAll?: boolean
+  global?: boolean
+  unicode?: boolean
+}
+
+export interface IValidatorRegexDictionary extends IBaseValidatorDictionary {
+  validate: 'regex_matches' | 'regex_excludes'
+  regex: string
+  regexFlags?: IRegexFlags
+}
+
+export interface IValidatorRequiredWithSimpleDictionary extends IBaseValidatorDictionary {
+  validate: 'required_with' | 'required_with_all' | 'required_without' | 'required_without_all'
+  fields: string[]
+}
+
+export interface IValidatorRequiredWithValuesDictionary extends IBaseValidatorDictionary {
+  validate:
+    | 'required_with_values'
+    | 'required_with_all_values'
+    | 'required_without_values'
+    | 'required_without_all_values'
+  fieldValues: ScalarDictionary
+}
+
+export type IValidatorRequiredWithDictionary =
+  | IValidatorRequiredWithSimpleDictionary
+  | IValidatorRequiredWithValuesDictionary
+
+export interface IValidatorOtherDictionary extends IBaseValidatorDictionary {
+  validate: 'required' | 'select' | 'unique' | 'boolean'
+}
+
+export interface IFieldOptionDictionary {
+  value: string | number | null
+  label: string
+  alternates?: string[]
+}
+
+export type IFieldOption = IFieldOptionDictionary
+
+export interface II18nOverrides {
+  otherLocales: string[]
+
+  /**
+   * @deprecated use importer.setLanguage('en')
+   */
+  setLanguage: string | undefined
+
+  overrides: IDictionary<string>
+}
+
+export interface IIntegrations {
+  adobeFontsWebProjectId?: string
+}
+
+export interface IStyleOverrides {
+  borderRadius?: string
+  borderTop?: string
+  borderImage?: string
+  buttonHeight?: string
+  primaryButtonColor?: string
+  primaryButtonBorderColor?: string
+  primaryButtonFontSize?: string
+  primaryButtonFontColor?: string
+  uploadButtonBackground?: string
+  uploadButtonPadding?: string
+  yesButtonBackground?: string
+  yesButtonPadding?: string
+  secondaryButtonColor?: string
+  secondaryButtonBorderColor?: string
+  secondaryButtonFontSize?: string
+  secondaryButtonFontColor?: string
+  noButtonColor?: string
+  noButtonBorderColor?: string
+  noButtonFontColor?: string
+  yesButtonColor?: string
+  yesButtonBorderColor?: string
+  yesButtonFontColor?: string
+  finalButtonSuccessColor?: string
+  finalButtonSuccessBorderColor?: string
+  finalButtonSuccessFontColor?: string
+  finalButtonErrorColor?: string
+  finalButtonErrorBorderColor?: string
+  finalButtonErrorFontColor?: string
+  invertedButtonColor?: string
+  linkColor?: string
+  linkAltColor?: string
+  primaryTextColor?: string
+  secondaryTextColor?: string
+  errorColor?: string
+  successColor?: string
+  warningColor?: string
+  borderColor?: string
+  fontFamily?: string
+}
+
+export interface IDictionary<V = string> {
+  [key: string]: V
+}
+export type Nullable<T> = T | undefined | null
+export type IPrimitive = string | number | boolean
+export type ScalarDictionary = IDictionary<Nullable<IPrimitive>>

--- a/src/obj.settings.ts
+++ b/src/obj.settings.ts
@@ -18,6 +18,11 @@ export interface ISettings {
   fields: IField[]
 
   /**
+   * Configure a list of columns that should be ignored.
+   */
+  ignoreColumns?: string[]
+
+  /**
    * Specific overrides to allow theming.
    * @deprecated use `theme`
    */
@@ -27,6 +32,7 @@ export interface ISettings {
    * Overrides to allow theming for most Portal elements.
    */
   theme?: ITheme
+
   /**
    * Boolean configuration which turns on dashboard functionality and sends data
    * to Flatfile's servers.
@@ -88,6 +94,11 @@ export interface ISettings {
    * Whether or not to allow users to select encoding
    */
   displayEncoding?: boolean
+
+  /**
+   * Whether or not to show "Are you sure?" dialog before closing
+   */
+  confirmClose?: boolean
 
   /**
    * Allows for additional rows to be added to the initial rows checked on import.

--- a/src/obj.settings.ts
+++ b/src/obj.settings.ts
@@ -175,14 +175,14 @@ export interface IFieldOptionDictionary {
 export type IFieldOption = IFieldOptionDictionary
 
 export interface II18nOverrides {
-  otherLocales: string[]
+  otherLocales?: string[]
 
   /**
-   * @deprecated use importer.setLanguage('en')
+   * @deprecated use `importer.setLanguage('en')`
    */
-  setLanguage: string | undefined
+  setLanguage?: string | undefined
 
-  overrides: IDictionary<string>
+  overrides: IDictionary<string | IDictionary<string>>
 }
 
 export interface IIntegrations {

--- a/src/obj.theme.ts
+++ b/src/obj.theme.ts
@@ -44,19 +44,39 @@ interface IStyleCSSTable extends IStyleTable {
   ':invalid'?: IStyleTable
 }
 
+type IStyleSelect = Pick<
+  CSSObject,
+  | 'backgroundColor'
+  | 'color'
+  | 'border'
+  | 'borderTop'
+  | 'borderRight'
+  | 'borderBottom'
+  | 'borderLeft'
+  | 'borderRadius'
+  | 'boxShadow'
+>
+
+interface IStyleCSSSelect extends IStyleSelect {
+  ':focus'?: IStyleSelect
+  ':active'?: IStyleSelect
+  ':selected'?: IStyleSelect
+}
+
 export interface ITheme {
   global?: {
-    backgroundColor?: string // default background color
-    textColor?: string // default text color
+    backgroundColor?: CSSObject['backgroundColor'] // default background color
+    textColor?: CSSObject['color'] // default text color
 
-    primaryTextColor?: string // primary text color
-    secondaryTextColor?: string // secondary text color
+    primaryTextColor?: CSSObject['color'] // primary text color
+    secondaryTextColor?: CSSObject['color'] // secondary text color
 
-    successColor?: string // default success color
-    warningColor?: string // default warning color
+    successColor?: CSSObject['color'] // default success color
+    warningColor?: CSSObject['color'] // default warning color
+
+    borderRadius?: CSSObject['borderRadius'] // default border radius
   }
   buttons?: {
-    // global
     primary?: IStyleCSSButton
     secondary?: IStyleCSSButton
     success?: IStyleCSSButton
@@ -122,6 +142,7 @@ export interface ITheme {
       th?: IStyleCSSTable
       td?: IStyleCSSTable
     }
+    select?: IStyleCSSSelect
   }
   columnMatch?: {
     root?: IStyleCSS
@@ -150,6 +171,7 @@ export interface ITheme {
     subtitle?: IStyleCSS
     step?: IStyleCSS
     footer?: IStyleCSS
+    select?: IStyleCSSSelect
   }
   loader?: {
     root?: IStyleCSS

--- a/src/obj.theme.ts
+++ b/src/obj.theme.ts
@@ -38,10 +38,21 @@ type IStyleTable = Pick<
   'backgroundColor' | 'color' | 'borderColor' | 'fontSize' | 'fontWeight' | 'textAlign'
 >
 
-interface IStyleCSSTable extends IStyleTable {
+interface IStyleCSSTableColumn extends IStyleTable {
+  ':focus'?: IStyleTable
+  ':hover'?: IStyleTable
+}
+
+interface IStyleCSSTableRow extends IStyleTable {
   ':focus'?: IStyleTable
   ':hover'?: IStyleTable
   ':invalid'?: IStyleTable
+}
+
+interface IStyleCSSTableRowIndex extends IStyleTable {
+  ':focus'?: IStyleTable
+  ':hover'?: IStyleTable
+  ':empty'?: IStyleTable
 }
 
 type IStyleSelect = Pick<
@@ -65,16 +76,40 @@ interface IStyleCSSSelect extends IStyleSelect {
 
 export interface ITheme {
   global?: {
-    backgroundColor?: CSSObject['backgroundColor'] // default background color
-    textColor?: CSSObject['color'] // default text color
+    /**
+     * default background color
+     */
+    backgroundColor?: CSSObject['backgroundColor']
 
-    primaryTextColor?: CSSObject['color'] // primary text color
-    secondaryTextColor?: CSSObject['color'] // secondary text color
+    /**
+     * default text color
+     */
+    textColor?: CSSObject['color']
 
-    successColor?: CSSObject['color'] // default success color
-    warningColor?: CSSObject['color'] // default warning color
+    /**
+     * default primary text color
+     */
+    primaryTextColor?: CSSObject['color']
 
-    borderRadius?: CSSObject['borderRadius'] // default border radius
+    /**
+     * default secondary text color
+     */
+    secondaryTextColor?: CSSObject['color']
+
+    /**
+     * default success color
+     */
+    successColor?: CSSObject['color']
+
+    /**
+     * default warning color
+     */
+    warningColor?: CSSObject['color']
+
+    /**
+     * default border radius
+     */
+    borderRadius?: CSSObject['borderRadius']
   }
   buttons?: {
     primary?: IStyleCSSButton
@@ -130,8 +165,9 @@ export interface ITheme {
     root?: IStyleCSS
     title?: IStyleCSS
     table?: {
-      th?: IStyleCSSTable
-      td?: IStyleCSSTable
+      th?: IStyleCSSTableColumn
+      td?: IStyleCSSTableRow
+      rowIndex?: IStyleCSSTableRowIndex
     }
   }
   headerMatch?: {
@@ -139,8 +175,8 @@ export interface ITheme {
     content?: IStyleCSS
     icon?: IStyleCSSSvg
     table?: {
-      th?: IStyleCSSTable
-      td?: IStyleCSSTable
+      th?: IStyleCSSTableColumn
+      td?: IStyleCSSTableRow
     }
     select?: IStyleCSSSelect
   }
@@ -155,15 +191,15 @@ export interface ITheme {
       field?: IStyleCSS
     }
     table?: {
-      th?: IStyleCSSTable
-      td?: IStyleCSSTable
+      th?: IStyleCSSTableColumn
+      td?: IStyleCSSTableRow
     }
   }
   dialog?: {
     root?: IStyleCSS
     content?: IStyleCSS
     footer?: IStyleCSS
-    overlayColor?: string // overlay color
+    overlayColor?: string
   }
   dataSource?: {
     root?: IStyleCSS
@@ -175,10 +211,20 @@ export interface ITheme {
   }
   loader?: {
     root?: IStyleCSS
-    overlayColor?: string // overlay color
+    overlayColor?: string
   }
   iterator?: {
     root?: IStyleCSS
-    overlayColor?: string // overlay color
+    overlayColor?: string
+
+    /**
+     * loader bar foreground color
+     */
+    barColor?: string
+
+    /**
+     * loader bar background color
+     */
+    barBackground?: string
   }
 }

--- a/src/obj.theme.ts
+++ b/src/obj.theme.ts
@@ -11,20 +11,20 @@ interface CSSObject extends CSSProperties, CSSPseudos {
 type IStyleCSS = Pick<
   CSSObject,
   | 'backgroundColor'
-  | 'color'
-  | 'padding'
-  | 'margin'
-  | 'fontSize'
-  | 'fontWeight'
-  | 'lineHeight'
   | 'border'
-  | 'borderTop'
-  | 'borderRight'
   | 'borderBottom'
   | 'borderLeft'
   | 'borderRadius'
-  | 'textAlign'
+  | 'borderRight'
+  | 'borderTop'
   | 'boxShadow'
+  | 'color'
+  | 'fontSize'
+  | 'fontWeight'
+  | 'lineHeight'
+  | 'margin'
+  | 'padding'
+  | 'textAlign'
 >
 
 type IStyleCSSButton = IStyleCSS & Pick<CSSObject, ':focus' | ':hover' | ':active'>
@@ -35,7 +35,7 @@ interface IStyleCSSSvg {
 
 type IStyleTable = Pick<
   CSSObject,
-  'backgroundColor' | 'color' | 'borderColor' | 'fontSize' | 'fontWeight' | 'textAlign'
+  'backgroundColor' | 'borderColor' | 'color' | 'fontSize' | 'fontWeight' | 'textAlign'
 >
 
 interface IStyleCSSTableColumn extends IStyleTable {
@@ -50,22 +50,22 @@ interface IStyleCSSTableRow extends IStyleTable {
 }
 
 interface IStyleCSSTableRowIndex extends IStyleTable {
+  ':empty'?: IStyleTable
   ':focus'?: IStyleTable
   ':hover'?: IStyleTable
-  ':empty'?: IStyleTable
 }
 
 type IStyleSelect = Pick<
   CSSObject,
   | 'backgroundColor'
-  | 'color'
   | 'border'
-  | 'borderTop'
-  | 'borderRight'
   | 'borderBottom'
   | 'borderLeft'
   | 'borderRadius'
+  | 'borderRight'
+  | 'borderTop'
   | 'boxShadow'
+  | 'color'
 >
 
 interface IStyleCSSSelect extends IStyleSelect {

--- a/src/obj.theme.ts
+++ b/src/obj.theme.ts
@@ -1,0 +1,162 @@
+import * as CSS from 'csstype'
+
+type CSSProperties = CSS.Properties<string | number>
+
+type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
+
+interface CSSObject extends CSSProperties, CSSPseudos {
+  [key: string]: CSSObject | string | number | undefined
+}
+
+type IStyleCSS = Pick<
+  CSSObject,
+  | 'backgroundColor'
+  | 'color'
+  | 'padding'
+  | 'margin'
+  | 'fontSize'
+  | 'fontWeight'
+  | 'lineHeight'
+  | 'border'
+  | 'borderTop'
+  | 'borderRight'
+  | 'borderBottom'
+  | 'borderLeft'
+  | 'borderRadius'
+  | 'textAlign'
+  | 'boxShadow'
+>
+
+type IStyleCSSButton = IStyleCSS & Pick<CSSObject, ':focus' | ':hover' | ':active'>
+
+interface IStyleCSSSvg {
+  fill?: string
+}
+
+type IStyleTable = Pick<
+  CSSObject,
+  'backgroundColor' | 'color' | 'borderColor' | 'fontSize' | 'fontWeight' | 'textAlign'
+>
+
+interface IStyleCSSTable extends IStyleTable {
+  ':focus'?: IStyleTable
+  ':hover'?: IStyleTable
+  ':invalid'?: IStyleTable
+}
+
+export interface ITheme {
+  global?: {
+    backgroundColor?: string // default background color
+    textColor?: string // default text color
+
+    primaryTextColor?: string // primary text color
+    secondaryTextColor?: string // secondary text color
+
+    successColor?: string // default success color
+    warningColor?: string // default warning color
+  }
+  buttons?: {
+    // global
+    primary?: IStyleCSSButton
+    secondary?: IStyleCSSButton
+    success?: IStyleCSSButton
+    tertiary?: IStyleCSSButton
+
+    dropzoneUpload?: IStyleCSSButton
+
+    headerMatchYes?: IStyleCSSButton
+    headerMatchNo?: IStyleCSSButton
+
+    columnMatchConfirm?: IStyleCSSButton
+    columnMatchConfirmWithDupes?: IStyleCSSButton
+    columnMatchIgnore?: IStyleCSSButton
+    columnMatchInclude?: IStyleCSSButton
+    columnMatchIncludeDropdown?: IStyleCSSButton
+    columnMatchEdit?: IStyleCSSButton
+
+    dialogConfirmYes?: IStyleCSSButton
+    dialogConfirmNo?: IStyleCSSButton
+
+    dialogFinalYes?: IStyleCSSButton
+    dialogFinalNo?: IStyleCSSButton
+
+    dialogFinalSuccess?: IStyleCSSButton
+    dialogFinalError?: IStyleCSSButton
+
+    dataSourceCancel?: IStyleCSSButton
+    dataSourceContinue?: IStyleCSSButton
+  }
+  header?: {
+    root?: IStyleCSS
+    title?: IStyleCSS
+    closeButton?: IStyleCSSButton
+  }
+  footer?: {
+    root?: IStyleCSS
+  }
+  progressBar?: {
+    root?: IStyleCSS
+    current?: IStyleCSS
+    complete?: IStyleCSS
+    incomplete?: IStyleCSS
+  }
+  dropzone?: {
+    root?: IStyleCSS
+    content?: IStyleCSS
+    fileTypes?: IStyleCSS
+    accepted?: IStyleCSS
+  }
+  manualInput?: {
+    root?: IStyleCSS
+    title?: IStyleCSS
+    table?: {
+      th?: IStyleCSSTable
+      td?: IStyleCSSTable
+    }
+  }
+  headerMatch?: {
+    root?: IStyleCSS
+    content?: IStyleCSS
+    icon?: IStyleCSSSvg
+    table?: {
+      th?: IStyleCSSTable
+      td?: IStyleCSSTable
+    }
+  }
+  columnMatch?: {
+    root?: IStyleCSS
+    content?: IStyleCSS
+    rule?: IStyleCSS
+    autoMatchRule?: {
+      root?: IStyleCSS
+      icon?: IStyleCSSSvg
+      description?: IStyleCSS
+      field?: IStyleCSS
+    }
+    table?: {
+      th?: IStyleCSSTable
+      td?: IStyleCSSTable
+    }
+  }
+  dialog?: {
+    root?: IStyleCSS
+    content?: IStyleCSS
+    footer?: IStyleCSS
+    overlayColor?: string // overlay color
+  }
+  dataSource?: {
+    root?: IStyleCSS
+    title?: IStyleCSS
+    subtitle?: IStyleCSS
+    step?: IStyleCSS
+    footer?: IStyleCSS
+  }
+  loader?: {
+    root?: IStyleCSS
+    overlayColor?: string // overlay color
+  }
+  iterator?: {
+    root?: IStyleCSS
+    overlayColor?: string // overlay color
+  }
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore


* **What is the current behavior?** (You can also link to an open issue here)
`settings` type was `object`


* **What is the new behavior (if this is a feature change)?**
`settings` type is `ISettings` with all field types


* **Other information**:
- `theme` is included and is using CSSProperties from `csstype` package
- `styleOverrides` is deprecated
- `i18nOverrides.setLanguage` is deprecated

![image](https://user-images.githubusercontent.com/25963776/107446538-48c76380-6b04-11eb-8f4d-5674d47567bd.png)
![image](https://user-images.githubusercontent.com/25963776/107446558-54b32580-6b04-11eb-8319-55880416ce40.png)

