### PR TITLE
Fix/fla 956 cors referrer policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "A lightweight TypeScript/JavaScript adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -304,6 +304,13 @@ export class FlatfileImporter extends EventEmitter {
       'beforeend',
       `<div id="flatfile-${this.uuid}" class="flatfile-component"></div>`
     )
+    const timeout = setTimeout(
+      () =>
+        console.error(
+          '[Flatfile] Looks like Portal takes too long to load. Please contact Flatfile support for any help.'
+        ),
+      5000
+    )
     this.handshake = Penpal.connectToChild({
       appendTo: document.getElementById(`flatfile-${this.uuid}`) || undefined,
       url: FlatfileImporter.MOUNT_URL.replace(':key', this.apiKey),
@@ -399,6 +406,10 @@ export class FlatfileImporter extends EventEmitter {
           return this.options
         }
       }
+    })
+
+    this.handshake.promise.then(() => {
+      if (timeout) clearTimeout(timeout)
     })
 
     this.handshake.promise.catch((err) => {


### PR DESCRIPTION
**Portal iframe is not connected to Adapter if [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) is set to `same-origin` without throwing any error messages.**

- [x] Display error message if for some reason child iframe is not connected to parent within 5 seconds.