### PR TITLE
FLA-1550 fix: remove getters for older TS versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "A lightweight TypeScript/JavaScript adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/results.ts
+++ b/src/results.ts
@@ -22,98 +22,191 @@ export class Results implements FlatfileResults {
    */
   private $importer: FlatfileImporter
 
-  constructor(data: Array<RecordObject>, meta: Meta, importer: FlatfileImporter) {
-    this.$meta = meta
-    this.$data = data
-    this.$importer = importer
-  }
-
   /**
    * The raw output from the importer including all deleted rows
    * and sequence info
    */
-  get rawOutput(): Array<RecordObject> {
-    return this.blobOnly(this.$data, 'rawOutput')
-  }
+  rawOutput: Array<RecordObject>
 
   /**
    * An array of valid data, key-mapped to the configuration provided
    * (alias of validData)
    */
-  get data(): Array<any> {
-    return this.blobOnly(this.validData, 'data')
-  }
+  data: Array<any>
 
   /**
    * An array of valid data, key-mapped to the configuration provided
    */
-  get validData(): Array<any> {
-    const res = this.$data
-      .filter((v) => v.valid)
-      .filter((v) => !v.deleted)
-      .map((v) => v.data)
-    return this.blobOnly(res, 'validData')
-  }
+  validData: Array<any>
 
   /**
    * Rows of data the user excluded from the final results,
    * key-mapped to the configuration provided
    */
-  get deletedData(): Array<any> {
-    const res = this.$data.filter((v) => v.deleted).map((v) => v.data)
-    return this.blobOnly(res, 'deletedData')
-  }
+  deletedData: Array<any>
 
   /**
    * All data from the original file upload including deleted rows,
    * key-mapped to the configuration provided
    */
-  get allData(): Array<any> {
-    return this.blobOnly(
-      this.$data.map((v) => v.data),
-      'allData'
-    )
-  }
+  allData: Array<any>
 
   /**
    * The uuid of the batch assigned by Flatfile (use this in internal
    * references for support purposes)
    */
-  get batchId(): string {
-    return this.$meta.batchID
-  }
+  batchId: string
 
   /**
    * Stats and counts about this file upload
    */
-  get stats(): Stats {
-    return new Stats(this.$meta)
-  }
+  stats: Stats
 
   /**
    * The customer provided in setCustomer
    */
-  get customer(): EndUser | null {
-    if (this.$meta.endUser) {
-      return new EndUser(this.$meta.endUser)
-    }
-    return null
-  }
+  customer: EndUser | null
 
   /**
    * A File object of the originally uploaded file stored as an AWS url
    */
-  get originalFile(): UploadFile | null {
-    if (this.$meta.originalFile) {
-      return new UploadFile(this.$meta.originalFile)
-    }
-    return null
-  }
+  originalFile: UploadFile | null
 
   /**
    * Same as originalFile unless it was uploaded in xls format, in which case this is the converted csv file stored as an AWS url
    */
-  get csvFile(): UploadFile | null {
+  csvFile: UploadFile | null
+
+  /**
+   * The filename of the originally uploaded file
+   */
+  fileName: string | null
+
+  /**
+   * If the final upload is managed by a private endpoint or not
+   */
+  managed: boolean
+
+  /**
+   * If the data was entered manually instead of via file upload or not
+   */
+  manual: boolean
+
+  /**
+   * The parsed and bootstrapped config object used by this importer instance
+   */
+  config: object
+
+  /**
+   * The configuration used by the csv parser PapaParse: https://www.papaparse.com/docs#config
+   */
+  parsingConfig: object
+
+  /**
+   * The invalid rows that were skipped on submission
+   */
+  skippedRows: number | null
+
+  /**
+   * The headers before they were matched as given in the original file
+   */
+  headersRaw: Array<object> | null
+
+  /**
+   * The headers after they are matched
+   */
+  headersMatched: Array<object> | null
+
+  /**
+   * An array of any columns that were created during import
+   */
+  customColumns: Array<object>
+
+  /**
+   * A mapping of source values to target category values
+   */
+  categoryFieldMap: object | null
+
+  /**
+   * The reason for the failure if there was a failure
+   */
+  failureReason: string | null
+
+  /**
+   * The time that the data was submitted
+   */
+  submittedAt: string | null
+
+  /**
+   * The time that the import failed if it failed
+   */
+  failedAt: string | null
+
+  /**
+   * The time the data began the import, whether via file upload or manual data entry
+   */
+  createdAt: string
+
+  /**
+   * The stylesheet of the cells. Make sure to use `allowFormatting=true` in the config.
+   */
+  stylesheet: Meta['stylesheet'] | null
+
+  /**
+   * Get the next chunk of records
+   */
+  nextChunk: () => Promise<null | StreamedResults>
+
+  constructor(data: Array<RecordObject>, meta: Meta, importer: FlatfileImporter) {
+    this.$meta = meta
+    this.$data = data
+    this.$importer = importer
+
+    this.rawOutput = this.blobOnly(this.$data, 'rawOutput')
+    this.data = this.blobOnly(this.validData, 'data')
+
+    this.validData = this.blobOnly(
+      this.$data
+        .filter((v) => v.valid)
+        .filter((v) => !v.deleted)
+        .map((v) => v.data),
+      'validData'
+    )
+
+    this.deletedData = this.blobOnly(
+      this.$data.filter((v) => v.deleted).map((v) => v.data),
+      'deletedData'
+    )
+    this.allData = this.blobOnly(
+      this.$data.map((v) => v.data),
+      'allData'
+    )
+
+    this.batchId = this.$meta.batchID
+    this.stats = new Stats(this.$meta)
+    this.customer = this.$meta.endUser ? new EndUser(this.$meta.endUser) : null
+    this.originalFile = this.$meta.originalFile ? new UploadFile(this.$meta.originalFile) : null
+    this.csvFile = this.getCSVFile()
+    this.fileName = this.$meta.filename || null
+    this.managed = this.$meta.managed || false
+    this.manual = this.$meta.manual
+    this.config = this.$meta.config
+    this.parsingConfig = this.$meta.parsing_config
+    this.skippedRows = this.$meta.skipped_rows || null
+    this.headersRaw = this.$meta.headers_raw || null
+    this.headersMatched = this.$meta.headers_matched || null
+    this.customColumns = this.$meta.custom_columns
+    this.categoryFieldMap = this.$meta.category_field_map || null
+    this.failureReason = this.$meta.failure_reason || null
+    this.submittedAt = this.$meta.submitted_at || null
+    this.failedAt = this.$meta.failed_at || null
+    this.createdAt = this.$meta.created_at
+    this.stylesheet = this.$meta.stylesheet
+
+    this.nextChunk = () => this.getNextChunk()
+  }
+
+  private getCSVFile() {
     if (this.$meta.originalFile) {
       if (this.$meta.originalFile.filetype === 'csv') {
         return new UploadFile(this.$meta.originalFile)
@@ -126,124 +219,7 @@ export class Results implements FlatfileResults {
     return null
   }
 
-  /**
-   * The filename of the originally uploaded file
-   */
-  get fileName(): string | null {
-    return this.$meta.filename || null
-  }
-
-  /**
-   * If the final upload is managed by a private endpoint or not
-   */
-  get managed(): boolean {
-    return this.$meta.managed || false
-  }
-
-  /**
-   * If the data was entered manually instead of via file upload or not
-   */
-  get manual(): boolean {
-    return this.$meta.manual
-  }
-
-  /**
-   * The parsed and bootstrapped config object used by this importer instance
-   */
-  get config(): object {
-    return this.$meta.config
-  }
-
-  /**
-   * The configuration used by the csv parser PapaParse: https://www.papaparse.com/docs#config
-   */
-  get parsingConfig(): object {
-    return this.$meta.parsing_config
-  }
-
-  /**
-   * The invalid rows that were skipped on submission
-   */
-  get skippedRows(): number | null {
-    return this.$meta.skipped_rows || null
-  }
-
-  /**
-   * The headers before they were matched as given in the original file
-   */
-  get headersRaw(): Array<object> | null {
-    return this.$meta.headers_raw || null
-  }
-
-  /**
-   * The headers after they are matched
-   */
-  get headersMatched(): Array<object> | null {
-    return this.$meta.headers_matched || null
-  }
-
-  /**
-   * An array of any columns that were created during import
-   */
-  get customColumns(): Array<object> {
-    return this.$meta.custom_columns
-  }
-
-  /**
-   * A mapping of source values to target category values
-   */
-  get categoryFieldMap(): object | null {
-    return this.$meta.category_field_map || null
-  }
-
-  /**
-   * The reason for the failure if there was a failure
-   */
-  get failureReason(): string | null {
-    return this.$meta.failure_reason || null
-  }
-
-  /**
-   * The time that the data was submitted
-   */
-  get submittedAt(): string | null {
-    return this.$meta.submitted_at || null
-  }
-
-  /**
-   * The time that the import failed if it failed
-   */
-  get failedAt(): string | null {
-    return this.$meta.failed_at || null
-  }
-
-  /**
-   * The time the data began the import, whether via file upload or manual data entry
-   */
-  get createdAt(): string {
-    return this.$meta.created_at
-  }
-
-  /**
-   * The stylesheet of the cells. Make sure to use `allowFormatting=true` in the config.
-   */
-  get stylesheet(): Meta['stylesheet'] | null {
-    return this.$meta.stylesheet
-  }
-
-  private blobOnly<T>(v: T, method, alt = 'nextChunk()'): T {
-    if (this.$meta.inChunks) {
-      throw new Error(
-        `"${method}" is not accessible when using "inChunks". Please see docs for "${alt}" instead.`
-      )
-    }
-    return v
-  }
-
-  /**
-   * Get the next chunk of records
-   */
-  nextChunk(): Promise<null | StreamedResults> {
+  private getNextChunk(): Promise<null | StreamedResults> {
     return new Promise((resolve, reject) => {
       if (!this.$meta.inChunks) {
         return reject(
@@ -263,5 +239,14 @@ export class Results implements FlatfileResults {
         )
       })
     })
+  }
+
+  private blobOnly<T>(v: T, method, alt = 'nextChunk()'): T {
+    if (this.$meta.inChunks) {
+      throw new Error(
+        `"${method}" is not accessible when using "inChunks". Please see docs for "${alt}" instead.`
+      )
+    }
+    return v
   }
 }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -3,35 +3,32 @@ import { Meta } from './interfaces'
 export class Stats {
   private $meta: Meta
 
-  constructor(meta: Meta) {
-    this.$meta = meta
-  }
-
   /**
    * The number of rows in the parsed data
    */
-  get originalRows(): number {
-    return this.$meta.count_rows
-  }
+  originalRows: number
 
   /**
    * The number of rows that were submitted
    */
-  get acceptedRows(): number | null {
-    return this.$meta.count_rows_accepted || null
-  }
+  acceptedRows: number | null
 
   /**
    * The number of columns in the parsed data
    */
-  get originalColumns(): number | null {
-    return this.$meta.count_columns || null
-  }
+  originalColumns: number | null
 
   /**
    * The number of columns submitted
    */
-  get matchedColumns(): number | null {
-    return this.$meta.count_columns_matched || null
+  matchedColumns: number | null
+
+  constructor(meta: Meta) {
+    this.$meta = meta
+
+    this.originalRows = this.$meta.count_rows
+    this.acceptedRows = this.$meta.count_rows_accepted || null
+    this.originalColumns = this.$meta.count_columns || null
+    this.matchedColumns = this.$meta.count_columns_matched || null
   }
 }

--- a/src/streamed-results.ts
+++ b/src/streamed-results.ts
@@ -11,85 +11,77 @@ export class StreamedResults {
    */
   private $data: Array<RecordObject>
 
-  constructor(data: Array<RecordObject>, meta: StreamedMeta) {
-    this.$meta = meta
-    this.$data = data
-  }
-
   /**
    * The raw output from the importer including all deleted rows
    * and sequence info
    */
-  get rawOutput(): Array<RecordObject> {
-    return this.$data
-  }
+  rawOutput: Array<RecordObject>
 
   /**
    * An array of valid data, key-mapped to the configuration provided
    * (alias of validData)
    */
-  get data(): Array<any> {
-    return this.validData
-  }
+  data: Array<any>
 
   /**
    * An array of valid data, key-mapped to the configuration provided
    */
-  get validData(): Array<any> {
-    return this.$data
-      .filter((v) => v.valid)
-      .filter((v) => !v.deleted)
-      .map((v) => v.data)
-  }
+  validData: Array<any>
 
   /**
    * Rows of data the user excluded from the final results,
    * key-mapped to the configuration provided
    */
-  get deletedData(): Array<any> {
-    return this.$data.filter((v) => v.deleted).map((v) => v.data)
-  }
+  deletedData: Array<any>
 
   /**
    * All data from the original file upload including deleted rows,
    * key-mapped to the configuration provided
    */
-  get allData(): Array<any> {
-    return this.$data.map((v) => v.data)
-  }
+  allData: Array<any>
 
   /**
    * The number of remaining chunks in the stream
    */
-  get remainingChunks(): number {
-    return Math.ceil((this.totalChunks - this.currentChunk) / this.$meta.inChunks)
-  }
+  remainingChunks: number
 
   /**
    * The total number of chunks that will have to be received before data processing is completed
    */
-  get totalChunks(): number {
-    return Math.ceil(this.$meta.count_rows_accepted / this.$meta.inChunks)
-  }
+  totalChunks: number
 
   /**
    * The size of chunks as configured when requesting data.
    */
-  get chunkSize(): number {
-    return this.$meta.inChunks
-  }
+  chunkSize: number
 
   /**
    * The current chunk by index
    */
-  get currentChunk(): number {
-    return (this.$meta.pointer + this.chunkSize) / this.chunkSize
-  }
+  currentChunk: number
 
   /**
    * The current chunk by index
    */
-  get hasMore(): boolean {
-    return this.$meta.hasMore
+  hasMore: boolean
+
+  constructor(data: Array<RecordObject>, meta: StreamedMeta) {
+    this.$meta = meta
+    this.$data = data
+
+    this.rawOutput = this.$data
+    this.validData = this.$data
+      .filter((v) => v.valid)
+      .filter((v) => !v.deleted)
+      .map((v) => v.data)
+
+    this.data = this.validData
+    this.deletedData = this.$data.filter((v) => v.deleted).map((v) => v.data)
+    this.allData = this.$data.map((v) => v.data)
+    this.remainingChunks = Math.ceil((this.totalChunks - this.currentChunk) / this.$meta.inChunks)
+    this.totalChunks = Math.ceil(this.$meta.count_rows_accepted / this.$meta.inChunks)
+    this.chunkSize = this.$meta.inChunks
+    this.currentChunk = (this.$meta.pointer + this.chunkSize) / this.chunkSize
+    this.hasMore = this.$meta.hasMore
   }
 }

--- a/src/upload-file.ts
+++ b/src/upload-file.ts
@@ -3,42 +3,37 @@ import { FileObject } from './interfaces'
 export class UploadFile {
   private $file: FileObject
 
-  constructor(file: FileObject) {
-    this.$file = file
-  }
-
   /**
    * A unique UUID referencing this file in the Flatfile system
    */
-  get id() {
-    return this.$file.id
-  }
+  id: string
 
   /**
    * The original filename on the user's system
    */
-  get filename() {
-    return this.$file.filename
-  }
+  filename: string
 
   /**
    * The size of the file in bytes
    */
-  get filesize() {
-    return this.$file.filesize
-  }
+  filesize: number
 
   /**
    * The type of file
    */
-  get filetype() {
-    return this.$file.filetype
-  }
+  filetype: string
 
   /**
    * A securely signed url giving you temporary access to download the file
    */
-  get url() {
-    return this.$file.url
+  url: string
+
+  constructor(file: FileObject) {
+    this.$file = file
+    this.id = this.$file.id
+    this.filename = this.$file.filename
+    this.filesize = this.$file.filesize
+    this.filetype = this.$file.filetype
+    this.url = this.$file.url
   }
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -3,49 +3,44 @@ import { EndUserObject } from './interfaces'
 export class EndUser {
   private $user: EndUserObject
 
-  constructor(meta: EndUserObject) {
-    this.$user = meta
-  }
-
   /**
    * The UUID referencing the user's record stored in Flatfile
    */
-  get id(): string {
-    return this.$user.id
-  }
+  id: string
 
   /**
    * Your internal ID reference for this user (required)
    */
-  get userId(): string {
-    return this.$user.userId
-  }
+  userId: string
 
   /**
    * The user's full name if you provided it
    */
-  get name(): string | undefined {
-    return this.$user.name
-  }
+  name: string | undefined
 
   /**
    * The user's email if you provided it
    */
-  get email(): string | undefined {
-    return this.$user.name
-  }
+  email: string | undefined
 
   /**
    * The company name the user is currently operating under
    */
-  get companyName(): string | undefined {
-    return this.$user.companyName
-  }
+  companyName: string | undefined
 
   /**
    * The company name the user is currently operating under
    */
-  get companyId(): string | undefined {
-    return this.$user.companyId
+  companyId: string | undefined
+
+  constructor(meta: EndUserObject) {
+    this.$user = meta
+
+    this.id = this.$user.id
+    this.userId = this.$user.userId
+    this.name = this.$user.name
+    this.email = this.$user.name
+    this.companyName = this.$user.companyName
+    this.companyId = this.$user.companyId
   }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Older TypeScript versions (like those found in Angular v8) throw errors when libraries use `getters`

![image](https://user-images.githubusercontent.com/2574412/129092662-e7d8ece8-ca8b-403c-94e3-ac1a6fbe6f77.png)




* **What is the new behavior (if this is a feature change)?**

Remove getters and initialize everything in the constructors to eliminate these errors so clients can use older versions of TypeScript or Angular without issues.

* **Other information**:

Angular v8 application running successfully with these changes (npm linked in node_modules)

![image](https://user-images.githubusercontent.com/2574412/129092726-e18dc928-8419-4d0c-b019-b1b477ff713f.png)

