### PR TITLE
Feat/ability to destroy importer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "es6-promise": "^4.2.8",
         "eventemitter3": "^4.0.7",
         "express": "^4.17.1",
-        "insert-css": "^2.0.0",
         "nqr": "^1.0.0",
         "penpal": "^3.0.1",
         "promise-polyfill": "^8.2.0",
@@ -9749,11 +9748,6 @@
       "dependencies": {
         "source-map": "~0.5.3"
       }
-    },
-    "node_modules/insert-css": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/insert-css/-/insert-css-2.0.0.tgz",
-      "integrity": "sha1-610Ql7dUL0x56jBg067gfQU4gPQ="
     },
     "node_modules/insert-module-globals": {
       "version": "7.2.1",
@@ -27657,11 +27651,6 @@
       "requires": {
         "source-map": "~0.5.3"
       }
-    },
-    "insert-css": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/insert-css/-/insert-css-2.0.0.tgz",
-      "integrity": "sha1-610Ql7dUL0x56jBg067gfQU4gPQ="
     },
     "insert-module-globals": {
       "version": "7.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.8.6",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.8.6",
+  "version": "2.9.0",
   "description": "A lightweight TypeScript/JavaScript adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "es6-promise": "^4.2.8",
     "eventemitter3": "^4.0.7",
     "express": "^4.17.1",
-    "insert-css": "^2.0.0",
     "nqr": "^1.0.0",
     "penpal": "^3.0.1",
     "promise-polyfill": "^8.2.0",

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'eventemitter3'
 import whenDomReady from 'when-dom-ready'
-import insertCss from 'insert-css'
 import elementClass from 'element-class'
 import Penpal from 'penpal'
 import {
@@ -19,6 +18,7 @@ import {
   StepHooks
 } from './interfaces'
 import { Results } from './results'
+import { insertCss } from './utils/insertCss'
 
 export class FlatfileImporter extends EventEmitter {
   public static Promise = Promise
@@ -33,9 +33,10 @@ export class FlatfileImporter extends EventEmitter {
   private options: ISettings
   private customer?: CustomerObject
   private uuid: string
+  private styleElement?: HTMLStyleElement
 
   // @ts-ignore
-  private handshake: Penpal.IChildConnectionObject
+  private handshake: Penpal.IChildConnectionObject | null
 
   private $resolver: (data: any) => any
   private $rejecter: (err: any) => any
@@ -95,6 +96,9 @@ export class FlatfileImporter extends EventEmitter {
    * Call open() to activate the importer overlay dialog.
    */
   open(options = {}): void {
+    if (this.handshake === null) {
+      throw new Error('This importer has been destroyed.')
+    }
     options = {
       ...options,
       bulkInit: true,
@@ -267,6 +271,15 @@ export class FlatfileImporter extends EventEmitter {
     this.$ready.then((child) => {
       child.close()
     })
+  }
+
+  /**
+   * This will remove the importer's HTML element and will destroy the connection.
+   * You wouldn't be able to open an importer if this method gets called.
+   */
+  destroy() {
+    document.getElementById(`flatfile-${this.uuid}`)?.remove()
+    this.handshake = null
   }
 
   private handleClose() {

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -33,7 +33,6 @@ export class FlatfileImporter extends EventEmitter {
   private options: ISettings
   private customer?: CustomerObject
   private uuid: string
-  private styleElement?: HTMLStyleElement
 
   // @ts-ignore
   private handshake: Penpal.IChildConnectionObject | null

--- a/src/utils/insertCss.ts
+++ b/src/utils/insertCss.ts
@@ -1,0 +1,25 @@
+let styleElement
+
+export const insertCss = (css: string) => {
+  if (!css) {
+    return
+  }
+
+  if (styleElement) {
+    return
+  }
+
+  styleElement = document.createElement('style')
+  styleElement.setAttribute('type', 'text/css')
+  document.querySelector('head')?.appendChild(styleElement)
+
+  if (css.charCodeAt(0) === 0xfeff) {
+    css = css.substr(1, css.length)
+  }
+
+  if (styleElement.styleSheet) {
+    styleElement.styleSheet.cssText += css
+  } else {
+    styleElement.textContent += css
+  }
+}

--- a/src/utils/insertCss.ts
+++ b/src/utils/insertCss.ts
@@ -14,7 +14,7 @@ export const insertCss = (css: string) => {
   document.querySelector('head')?.appendChild(styleElement)
 
   if (css.charCodeAt(0) === 0xfeff) {
-    css = css.substr(1, css.length)
+    css = css.substr(1)
   }
 
   if (styleElement.styleSheet) {

--- a/src/utils/insertCss.ts
+++ b/src/utils/insertCss.ts
@@ -20,6 +20,6 @@ export const insertCss = (css: string) => {
   if (styleElement.styleSheet) {
     styleElement.styleSheet.cssText = css
   } else {
-    styleElement.textContent += css
+    styleElement.textContent = css
   }
 }

--- a/src/utils/insertCss.ts
+++ b/src/utils/insertCss.ts
@@ -18,7 +18,7 @@ export const insertCss = (css: string) => {
   }
 
   if (styleElement.styleSheet) {
-    styleElement.styleSheet.cssText += css
+    styleElement.styleSheet.cssText = css
   } else {
     styleElement.textContent += css
   }


### PR DESCRIPTION
- [x] Removed `insert-css` package
- [x] Added local `insertCss` function which would prevent duplicate stylings if multiple adapters are on the same page.
- [x] Added ability to destroy the importer (remove HTML element and kill the Penpal connection) - needed this for https://linear.app/flatfile/issue/FLA-796/is-react-adapter-still-creating-duplicated-iframes-when-navigating

![image](https://user-images.githubusercontent.com/25963776/130823091-16bf84cb-c185-4b05-bd20-9a0cba487109.png)
