### PR TITLE
feat(adapter): added bulk init record hook;

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/adapter",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "A lightweight TypeScript/JavaScript adapter for working with Flatfile's Portal",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -54,8 +54,7 @@ export class FlatfileImporter extends EventEmitter {
     mode: string
   ) => IDataHookResponse | Promise<IDataHookResponse>
   private $bulkInitRecordHook?: (
-    rows: [HookRecordObject, number][],
-    mode: string
+    rows: [HookRecordObject, number][]
   ) => IDataHookResponse[] | Promise<IDataHookResponse[]>
   private $fieldHooks: Array<{ field: string; cb: FieldHookCallback }> = []
   private $stepHooks: StepHooks = {} as StepHooks
@@ -376,9 +375,9 @@ export class FlatfileImporter extends EventEmitter {
         bulkHookCallback: (rows, mode) => {
           if (this.$bulkInitRecordHook) {
             try {
-              return this.$bulkInitRecordHook(rows, mode)
+              return this.$bulkInitRecordHook(rows)
             } catch ({ stack }) {
-              console.error(`Flatfile Bulk Init Record Hook Error:\n  ${stack}`, { rows, mode })
+              console.error(`Flatfile Bulk Init Record Hook Error:\n  ${stack}`, { rows })
 
               return {}
             }

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -378,7 +378,6 @@ export class FlatfileImporter extends EventEmitter {
               return this.$bulkInitRecordHook(rows)
             } catch ({ stack }) {
               console.error(`Flatfile Bulk Init Record Hook Error:\n  ${stack}`, { rows })
-
               return {}
             }
           }

--- a/src/interfaces/obj.record.ts
+++ b/src/interfaces/obj.record.ts
@@ -21,3 +21,4 @@ export interface RecordObject {
 }
 
 export type RawRecordObject = Record<string, string> & { $custom?: Record<string, string> }
+export type HookRecordObject = { [key: string]: string | number }


### PR DESCRIPTION
ref #125 for more info

Note: bulk hook will be only called on init (not on change)

Code example:

```js
importer.registerBulkInitRecordHook((rows) => {
 return rows.map(([row, rowIndex]) => {
    return {
      name: {
        value: row.name.replace(/[^a-zA-Z]+/g, ''),
        info: [
          {
            message: 'Stripped non alphabet characters',
            level: 'info'
          }
        ]
      }
    }
  })
})
```